### PR TITLE
prime: force permutation's factoradic to be int list

### DIFF
--- a/prime.py
+++ b/prime.py
@@ -155,7 +155,7 @@ class Prime():
         return r
     
     def getNthPermutation(self,symbols, n):
-        return self.permutation(symbols, self.n_to_factoradic(n))
+        return self.permutation(symbols, map(int, self.n_to_factoradic(n)))
 
 
     def n_to_factoradic(self,n, p = 2):


### PR DESCRIPTION
There was a strange error for me where permuatation was
receiving a 2nd argument of [1.0, 0]. I have no real
understanding of the issue, but coercing the values
to int seems to not give me the right results.

was:

```
    >>> import rasterfairy
    >>> rasterfairy.getRectArrangements(4900)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "rasterfairy.py", line 373, in getRectArrangements
        perms = set(p.getPermutations(f))
      File "prime.py", line 121, in getPermutations
        perm.append(self.getNthPermutation(symbols, i))
      File "prime.py", line 158, in getNthPermutation
        return self.permutation(symbols, map(int, self.n_to_factoradic(n)))
      File "prime.py", line 178, in permutation
        ret.append(s[f])
    TypeError: list indices must be integers, not float
```

now:

```
    >>> import rasterfairy
    >>> rasterfairy.getRectArrangements(4900)
    [(70, 70), (50, 98), (49, 100), (35, 140), (28, 175), (25, 196), (20, 245), (14, 350), (10, 490), (7, 700), (5, 980), (4, 1225), (2, 2450), (1, 4900)]
```
