### PR TITLE
Update transformPointCloud2D to also return quadrants

### DIFF
--- a/rasterfairy/rasterfairy.py
+++ b/rasterfairy/rasterfairy.py
@@ -126,7 +126,7 @@ def transformPointCloud2D( points2d, target = None, autoAdjustCount = True, prop
     for q in quadrants:
         gridPoints2d[q['indices'][0]] = np.array(q['grid'][0:2],dtype=np.float)
 
-    return gridPoints2d, (width, height)
+    return gridPoints2d, (width, height), quadrants
 
 
 def sliceQuadrant( quadrant, mask = None ):


### PR DESCRIPTION
This provides access to the indices of the elements.

Not sure if this is the cleanest API, but my main use case is to get the indices of the vectors and this was the simplest change to achieve this.
