### PR TITLE
Port RasterFairy for Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# About RasterFairy-Py3
+
+This is a fork of the official RasterFairy that has Python 3 support. Since the official repo isn't maintained (there is an unmerged pull request for Python 3 from [April, 2017](https://github.com/Quasimondo/RasterFairy/pull/8)), I made a Python 3 compatible version on my own.
+
+Below is the README from the official RasterFairy repo.
+
 # RasterFairy
 The purpose of Raster Fairy is to transform any kind of 2D point cloud into a regular raster whilst trying to preserve the neighborhood relations that were present in the original cloud. A typical use case is if you have a similarity clustering of images and want to show the images in a regular table structure.
 

--- a/rasterfairy/__init__.py
+++ b/rasterfairy/__init__.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 """Top-level module for RasterFairy"""
 
-from rasterfairy import *
-from coonswarp import *
-from rfoptimizer import *
-from images2gif import *
+from .rasterfairy import *
+from .coonswarp import *
+from .rfoptimizer import *
+# from images2gif import *
 

--- a/rasterfairy/coonswarp.py
+++ b/rasterfairy/coonswarp.py
@@ -1,4 +1,7 @@
-# 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+#
 # Coon Warp v1.0,
 # released 23.01.2016
 #
@@ -32,6 +35,7 @@
 # ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 from scipy.spatial import ConvexHull, KDTree, distance
 import numpy as np
@@ -303,4 +307,3 @@ def getPointOnHull( hullPoints,t, totalLength ):
             t-= t_sub;
         else :
             return lerp(hullPoints[j%lh],hullPoints[(j+1)%lh], t / t_sub );
-         

--- a/rasterfairy/prime.py
+++ b/rasterfairy/prime.py
@@ -1,4 +1,7 @@
-# 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+#
 # Prime Number Utility v1.02
 # part of Raster Fairy v1.0,
 # released 22.01.2016
@@ -120,7 +123,7 @@ class Prime():
                 perm.append(self.getNthPermutation(symbols, i))
                
         else:
-            print "not enough memory for amount of possible permutations, creating grouped set"
+            print("not enough memory for amount of possible permutations, creating grouped set")
             groupedSymbols = []
             lastSymbol = symbols[0]
             c = 1
@@ -160,7 +163,7 @@ class Prime():
     def n_to_factoradic(self,n, p = 2):
         if n < p:
             return [n]
-        ret = self.n_to_factoradic((n / p) | 0, p + 1)
+        ret = self.n_to_factoradic((n // p) | 0, p + 1)
         ret.append(n % p)
         return ret
     

--- a/rasterfairy/rasterfairy.py
+++ b/rasterfairy/rasterfairy.py
@@ -1,4 +1,7 @@
-# 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+#
 # Raster Fairy v1.0.3,
 # released 22.01.2016
 #
@@ -39,8 +42,10 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
-import prime
+from rasterfairy import prime
+from rasterfairy.utils import cmp_to_key
 import math
+
 
 def transformPointCloud2D( points2d, target = None, autoAdjustCount = True, proportionThreshold = 0.4):
     pointCount = len(points2d)
@@ -48,16 +53,16 @@ def transformPointCloud2D( points2d, target = None, autoAdjustCount = True, prop
     
     if target is None:
         target = getRectArrangements(pointCount)[0]
-        if (float(target[0]) / float(target[1])<proportionThreshold):
+        if float(target[0]) / float(target[1])<proportionThreshold:
             width = int(math.sqrt(pointCount))
             height = int(math.ceil(float(pointCount)/float(width)))
-            print "no good rectangle found for",pointCount,"points, using incomplete square",width,"*",height
+            print("no good rectangle found for",pointCount,"points, using incomplete square",width,"*",height)
             target = {'width':width,'height':height,'mask':np.zeros((height,width),dtype=int), 'count':width*height, 'hex': False}
         
     if type(target) is tuple and len(target)==2:
         #print "using rectangle target"
         if target[0] * target[1] < pointCount:
-            print "ERROR: target rectangle is too small to hold data: Rect is",target[0],"*",target[1],"=",target[0] * target[1]," vs ",pointCount," data points"
+            print("ERROR: target rectangle is too small to hold data: Rect is",target[0],"*",target[1],"=",target[0] * target[1]," vs ",pointCount," data points")
             return False
         width = target[0]
         height = target[1]
@@ -74,7 +79,7 @@ def transformPointCloud2D( points2d, target = None, autoAdjustCount = True, prop
         height = rasterMask['height']
     
     if not (rasterMask is None) and rasterMask['mask'].shape[0]*rasterMask['mask'].shape[1]-np.sum( rasterMask['mask'].flat) < len(points2d):
-        print "ERROR: raster mask target does not have enough grid points to hold data"
+        print("ERROR: raster mask target does not have enough grid points to hold data")
         return False
     
     if not (rasterMask is None) and (rasterMask['count']!=len(points2d)):
@@ -116,7 +121,7 @@ def transformPointCloud2D( points2d, target = None, autoAdjustCount = True, prop
             i+=1
             
     if failedSlices>0:
-        print "WARNING - There might be a problem with the data. Try using autoAdjustCount=True as a workaround or check if you have points with identical coordinates in your set."
+        print("WARNING - There might be a problem with the data. Try using autoAdjustCount=True as a workaround or check if you have points with identical coordinates in your set.")
 
     gridPoints2d = points2d.copy()
 
@@ -126,7 +131,7 @@ def transformPointCloud2D( points2d, target = None, autoAdjustCount = True, prop
         if np.argmin(rasterMask['mask'][0]) > np.argmin(rasterMask['mask'][1]):
             offset = 0.5
         for q in quadrants:
-            if (q['grid'][1]%2==0):
+            if q['grid'][1]%2==0:
                 q['grid'][0]-=offset
             q['grid'][1] *= f
 
@@ -173,7 +178,8 @@ def sliceQuadrant( quadrant, mask = None ):
             pointsPerSlice = grid[2] * sliceSize
             gridOffset = grid[1]
         for i in range(sliceCount):
-            sliceObject = {} 
+            sliceObject = {}
+            print(pointsPerSlice)
             sliceObject['points'] = xy[order[i*pointsPerSlice:(i+1)*pointsPerSlice]]
             if len(sliceObject['points'])>0:
                 sliceObject['indices'] = indices[order[i*pointsPerSlice:(i+1)*pointsPerSlice]]
@@ -363,7 +369,7 @@ def getCircleRasterMask( r, innerRingRadius = 0, rasterCount = None, autoAdjustC
             p[zeros[0:count-rasterCount]] = 1
             count = rasterCount        
         p = p.reshape((d,d))
-    #print "adjusted count",p.shape[0] * p.shape[1]- np.sum(p)
+    #print("adjusted count",p.shape[0] * p.shape[1]- np.sum(p))
     return {'width':d,'height':d,'mask':p, 'count':count}
         
 def getRectArrangements(n):
@@ -381,7 +387,7 @@ def getRectArrangements(n):
                 v2 = multiplyArray(perm[i:])
                 arrangements.add((min(v1, v2),max(v1, v2)))
 
-    return sorted(list(arrangements), cmp=proportion_sort, reverse=True)
+    return sorted(list(arrangements), key=cmp_to_key(proportion_sort), reverse=True)
 
 def getShiftedAlternatingRectArrangements(n):
     arrangements = set([])

--- a/rasterfairy/rasterfairy.py
+++ b/rasterfairy/rasterfairy.py
@@ -119,7 +119,6 @@ def transformPointCloud2D( points2d, target = None, autoAdjustCount = True, prop
                 failedSlices += 1
         else:
             i+=1
-            
     if failedSlices>0:
         print("WARNING - There might be a problem with the data. Try using autoAdjustCount=True as a workaround or check if you have points with identical coordinates in your set.")
 
@@ -179,7 +178,8 @@ def sliceQuadrant( quadrant, mask = None ):
             gridOffset = grid[1]
         for i in range(sliceCount):
             sliceObject = {}
-            print(pointsPerSlice)
+            # HOTFIX: indices must be integers!
+            pointsPerSlice = int(pointsPerSlice)
             sliceObject['points'] = xy[order[i*pointsPerSlice:(i+1)*pointsPerSlice]]
             if len(sliceObject['points'])>0:
                 sliceObject['indices'] = indices[order[i*pointsPerSlice:(i+1)*pointsPerSlice]]
@@ -394,12 +394,12 @@ def getShiftedAlternatingRectArrangements(n):
     for x in range(1,n >> 1):
         v = 2 * x + 1
         if n % v == x:
-            arrangements.add((x, x + 1, ((n / v) | 0) * 2 + 1))
+            arrangements.add((x, x + 1, ((n // v) | 0) * 2 + 1))
         
     for x in range(2,1 + (n >> 1)):
         v = 2 * x - 1
         if n % v == x:
-            arrangements.add((x, x - 1, ((n / v) | 0) * 2 + 1))
+            arrangements.add((x, x - 1, ((n // v) | 0) * 2 + 1))
     
     result = []
     for a in arrangements:
@@ -455,12 +455,12 @@ def getAlternatingRectArrangements(n):
     for x in range(1,n >> 1):
         v = 2 * x + 2
         if n % v == x:
-            arrangements.add((x, x + 2, ((n / v) | 0) * 2 + 1))
+            arrangements.add((x, x + 2, ((n // v) | 0) * 2 + 1))
         
     for x in range(2,1 + (n >> 1)):
         v = 2 * x - 2
         if n % v == x:
-            arrangements.add((x, x -2, ((n / v) | 0) * 2 + 1))
+            arrangements.add((x, x -2, ((n // v) | 0) * 2 + 1))
     
     result = []
     for a in arrangements:
@@ -530,7 +530,7 @@ def arrangementListToRasterMasks( arrangements ):
     masks = []
     for i in range(len(arrangements)):
         masks.append(arrangementToRasterMask(arrangements[i]))
-    return sorted(masks, cmp=arrangement_sort, reverse=True)
+    return sorted(masks, key=cmp_to_key(arrangement_sort), reverse=True)
 
 def arrangementToRasterMask( arrangement ):
     rows = np.array(arrangement['rows'])

--- a/rasterfairy/rfoptimizer.py
+++ b/rasterfairy/rfoptimizer.py
@@ -1,4 +1,7 @@
-# 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+#
 # Random Grid Swap Utility v1.0
 # part of Raster Fairy v1.02,
 # released 27.01.2016
@@ -95,12 +98,12 @@ class SwapOptimizer:
                 cy = int(0.5+self.grid_norm[j][1]*(height-1))
 
                 if (cx,cy) in ci:
-                    print "ERROR:",(cx,cy)," doubled"
+                    print("ERROR:",(cx,cy)," doubled")
                 cells[cx][cy] = j
                 ci[(cx,cy) ] = True
 
             if len(ci) != totalEntries:
-                print "ERROR in cell mapping"
+                print("ERROR in cell mapping")
                 return
 
             distances = dist.cdist(self.grid_norm, self.xy_norm, 'sqeuclidean')
@@ -123,11 +126,11 @@ class SwapOptimizer:
 
         bestQuality = startingQuality = self.sumDistances(swapTable,distances)
         startingSwapTable = swapTable.copy()
-        print "Starting sum of distances",startingQuality
+        print("Starting sum of distances",startingQuality)
         if shakeIterations > 0:
             self.shake(cells,swapTable,shakeIterations,1,width,height)
             bestQuality = self.sumDistances(swapTable,distances)
-            print "After shake sum of distances",bestQuality
+            print("After shake sum of distances",bestQuality)
 
         bestSwapTableBeforeAnnealing = swapTable.copy()
         toleranceSteps = 0
@@ -135,9 +138,9 @@ class SwapOptimizer:
         for i in range(iterations):
             if i>0 and i % 20000 == 0:
                 clear_output(wait=True)
-                print "Starting sum of distances",startingQuality
+                print("Starting sum of distances",startingQuality)
             if i % 1000 == 0:
-                print i,bestQuality
+                print(i,bestQuality)
 
             if toleranceSteps == 0:
                 swapTable = bestSwapTableBeforeAnnealing.copy()
@@ -366,10 +369,10 @@ class SwapOptimizer:
 
         if bestQuality > startingQuality:
             bestSwapTableBeforeAnnealing = startingSwapTable
-        print "final distance sum:",bestQuality
-        print "improvement:", startingQuality-bestQuality 
+        print("final distance sum:",bestQuality)
+        print("improvement:", startingQuality-bestQuality)
         if startingQuality<bestQuality:
-            print "reverting to initial swap table"
+            print("reverting to initial swap table")
         self.lastState = {'cells':cells,'iterations':totalIterations, 'distances':distances,
                                               'swapChoiceWeights':swapChoiceWeights,'swapOffsetWeights':swapOffsetWeights,
                                               'colSizeWeights':colSizeWeights,'rowSizeWeights':rowSizeWeights,

--- a/rasterfairy/utils.py
+++ b/rasterfairy/utils.py
@@ -1,0 +1,37 @@
+def cmp_to_key(mycmp):
+    """
+    Convert `sorted` function from python2 to python3.
+
+    This function is used to convert `cmp` parameter of python2 sorted
+    function into `key` parameter of python3 sorted function.
+
+    This code is taken from here:
+    https://docs.python.org/2/howto/sorting.html#the-old-way-using-the-cmp-parameter
+
+    :param mycmp: compare function that compares 2 values
+    :return: key class that compares 2 values
+    """
+    "Convert a cmp= function into a key= function"
+    class K(object):
+        def __init__(self, obj, *args):
+            self.obj = obj
+
+        def __lt__(self, other):
+            return mycmp(self.obj, other.obj) < 0
+
+        def __gt__(self, other):
+            return mycmp(self.obj, other.obj) > 0
+
+        def __eq__(self, other):
+            return mycmp(self.obj, other.obj) == 0
+
+        def __le__(self, other):
+            return mycmp(self.obj, other.obj) <= 0
+
+        def __ge__(self, other):
+            return mycmp(self.obj, other.obj) >= 0
+
+        def __ne__(self, other):
+            return mycmp(self.obj, other.obj) != 0
+    return K
+

--- a/setup.py
+++ b/setup.py
@@ -63,10 +63,11 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-    	'numpy >= 1.8.0',
-     	'scipy >= 0.13.0',
-     	'moviepy >= 0.2.3.5'
-	],
+        'numpy >= 1.8.0',
+        'scipy >= 0.13.0',
+        'moviepy >= 0.2.3.5',
+        'ipython',
+    ],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
@@ -81,7 +82,7 @@ setup(
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.
     package_data={
-        #'sample': ['package_data.dat'],
+        # 'sample': ['package_data.dat'],
     },
 
     # Although 'package_data' is the preferred approach, in some case you may
@@ -89,15 +90,15 @@ setup(
     # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
     # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
     data_files=[
-		#('my_data', ['data/data_file'])
-	],
+        # ('my_data', ['data/data_file'])
+    ],
 
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.
-    #entry_points={
+    # entry_points={
     #    'console_scripts': [
     #        'sample=sample:main',
     #    ],
-    #},
+    # },
 )


### PR DESCRIPTION
I am working on a project, and I found RasterFairy to be useful for what I am doing. Unfortunately, it only supported Python 2.7. I was able to make it successfully run on Python 3.6.

Mainly, the fixes included:
- print function
- integer division
- `sorted()` function

I ran the first example notebook both in Python 2.7 and Python 3.6 and it all worked.