### PR TITLE
Fix: Update setup.py dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,7 @@ setup(
     install_requires=[
         'numpy >= 1.8.0',
         'scipy >= 0.13.0',
-        'moviepy >= 0.2.3.5',
-        'colorsys'
+        'Pillow >= 8.0.0'
     ],
 
     # List additional groups of dependencies here (e.g. development
@@ -74,8 +73,9 @@ setup(
     # for example:
     # $ pip install -e .[dev,test]
     extras_require={
-        'dev': ['check-manifest'],
+        'dev': ['check-manifest', 'moviepy >= 0.2.3.5'],
         'test': ['coverage'],
+        'examples': ['colorsys'],
     },
 
     # If there are data files included in your packages that need to be


### PR DESCRIPTION
- Add Pillow to install_requires as it is used for image-based targets.
- Move moviepy to extras_require['dev'] as it is not used by the core library or basic examples.
- Move colorsys to extras_require['examples'] as it is used in example scripts but not by the core library.